### PR TITLE
reversed logic in train_scripts

### DIFF
--- a/dlsia/core/train_scripts.py
+++ b/dlsia/core/train_scripts.py
@@ -247,7 +247,7 @@ def train_segmentation(net, trainloader, validationloader, NUM_EPOCHS,
                 print('   Network intermittently saved')
                 print('')
 
-    if validationloader is not None:
+    if validationloader is None:
         validation_loss = None
         F1_validation_trace_micro = None
         F1_validation_trace_macro = None


### PR DESCRIPTION
Accessing F1_validation_trace_micro and _macro when a validation loader is provided in the call to train_segmentation results in an error being thrown as they are set to None